### PR TITLE
Reduce prod memory limits and add umami restart cron

### DIFF
--- a/cron/pi-site
+++ b/cron/pi-site
@@ -1,0 +1,5 @@
+# pi-site cron jobs
+# Installed to /etc/cron.d/pi-site by deploy.sh
+
+# Restart umami daily at 4am to clear memory leak
+0 4 * * * root docker restart pi-site-umami-1 >/dev/null 2>&1

--- a/deploy.sh
+++ b/deploy.sh
@@ -85,6 +85,16 @@ configure_nginx() {
   sudo systemctl reload nginx || sudo systemctl start nginx
 }
 
+configure_cron() {
+  log "Configuring cron jobs..."
+
+  local cron_file="${APP_DIR}/cron/pi-site"
+  [[ -f "$cron_file" ]] || { warn "No cron config found, skipping"; return; }
+
+  sudo cp "$cron_file" /etc/cron.d/pi-site
+  sudo chmod 644 /etc/cron.d/pi-site
+}
+
 # -------------------------
 # Main
 # -------------------------
@@ -96,6 +106,7 @@ install_docker_if_needed
 ensure_docker_running
 install_nginx_if_needed
 configure_nginx
+configure_cron
 
 log "Running deployment..."
 # Delegate to the Compose-focused deployment script

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -57,10 +57,10 @@ services:
       resources:
         limits:
           cpus: "2"
-          memory: 1536M
+          memory: 512M
         reservations:
           cpus: "0.5"
-          memory: 768M
+          memory: 384M
     healthcheck:
       test:
         [


### PR DESCRIPTION
- chore(docker): reduce prod container memory limits
- feat(deploy): add cron configuration for daily umami restart

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented automatic daily service restart schedule to enhance system reliability.
  * Optimized container resource allocations for improved efficiency.
  * Enhanced deployment configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->